### PR TITLE
Update arguments for 'create-text' and how they are parsed.

### DIFF
--- a/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommand.cs
+++ b/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommand.cs
@@ -12,21 +12,22 @@ public class CreateTextCommand : CliCommand
     /// </summary>
     public CreateTextCommand() : base("create-text")
     {
-        Description = "Create text for a GitHub release between a previous tag and now.";
+        Description = "Create text for a GitHub release between two commits.";
 
         Options.Add(
-            new CliOption<string>("--base-tag")
+            new CliOption<string>("--base-ref")
             {
-                Description = "The base tag to compare against.",
+                Description = "The base ref to compare against.",
                 Required = true
             }
         );
 
         Options.Add(
-            new CliOption<string>("--new-tag")
+            new CliOption<string>("--target-ref")
             {
-                Description = "The new tag to compare against.",
-                Required = true
+                Description = "The target ref to compare against.",
+                Required = true,
+                DefaultValueFactory = (defaultValue) => "HEAD"
             }
         );
 
@@ -38,7 +39,7 @@ public class CreateTextCommand : CliCommand
         );
 
         Options.Add(
-            new CliOption<string>("--repo")
+            new CliOption<string>("--repo-name")
             {
                 Description = "The repository name."
             }

--- a/src/ConsoleApp/Models/Commands/CreateTextCommandOptions.cs
+++ b/src/ConsoleApp/Models/Commands/CreateTextCommandOptions.cs
@@ -1,0 +1,140 @@
+using System.CommandLine;
+
+namespace GitHubReleaseGen.ConsoleApp.Models.Commands;
+
+/// <summary>
+/// Options for the 'create-text' command.
+/// </summary>
+public sealed class CreateTextCommandOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateTextCommandOptions"/> class.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    public CreateTextCommandOptions(ParseResult parseResult)
+    {
+        BaseRef = ParseBaseRefArgument(parseResult);
+        TargetRef = ParseTargetRefArgument(parseResult);
+        RepoOwner = ParseRepoOwnerArgument(parseResult);
+        RepoName = ParseRepoNameArgument(parseResult);
+        LocalRepoPath = ParseLocalRepoPathArgument(parseResult);
+        ExcludeOverviewSection = ParseExcludeOverviewSectionArgument(parseResult);
+    }
+
+    /// <summary>
+    /// The base ref.
+    /// </summary>
+    public string BaseRef { get; set; }
+
+    /// <summary>
+    /// The target ref.
+    /// </summary>
+    public string TargetRef { get; set; }
+
+    /// <summary>
+    /// The repository owner.
+    /// </summary>
+    public string? RepoOwner { get; set; }
+
+    /// <summary>
+    /// The repository name.
+    /// </summary>
+    public string? RepoName { get; set; }
+
+    /// <summary>
+    /// The local repository path.
+    /// </summary>
+    public string? LocalRepoPath { get; set; }
+
+    /// <summary>
+    /// Whether to exclude the overview section.
+    /// </summary>
+    public bool ExcludeOverviewSection { get; set; }
+
+    /// <summary>
+    /// Parse the '--base-ref' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>The base ref.</returns>
+    /// <exception cref="NullReferenceException">Thrown when the base ref was not provided.</exception>
+    private static string ParseBaseRefArgument(ParseResult parseResult)
+    {
+        string baseRef = parseResult.GetValue<string>("--base-ref") ?? throw new NullReferenceException("Base ref is required.");
+
+        return baseRef;
+    }
+
+    /// <summary>
+    /// Parse the '--target-ref' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>The target ref.</returns>
+    /// <exception cref="NullReferenceException">Thrown when the target ref was not provided.</exception>
+    private static string ParseTargetRefArgument(ParseResult parseResult)
+    {
+        string targetRef = parseResult.GetValue<string>("--target-ref") ?? throw new NullReferenceException("Target ref is required.");
+
+        return targetRef;
+    }
+    
+    /// <summary>
+    /// Parse the '--repo-owner' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>The repository owner.</returns>
+    private static string? ParseRepoOwnerArgument(ParseResult parseResult)
+    {
+        string? repoOwner = parseResult.GetValue<string>("--repo-owner");
+
+        return repoOwner;
+    }
+
+    /// <summary>
+    /// Parse the '--repo-name' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>The repository name.</returns>
+    private static string? ParseRepoNameArgument(ParseResult parseResult)
+    {
+        string? repoName = parseResult.GetValue<string>("--repo-name");
+
+        return repoName;
+    }
+
+    /// <summary>
+    /// Parse the '--local-repo-path' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>The local repository path.</returns>
+    /// <exception cref="DirectoryNotFoundException">Thrown when the local repository path does not exist.</exception>
+    private static string? ParseLocalRepoPathArgument(ParseResult parseResult)
+    {
+        string? localRepoPath = parseResult.GetValue<string>("--local-repo-path");
+
+        string? localRepoPathFull = null;
+
+        if (localRepoPath is not null)
+        {
+            localRepoPathFull = Path.GetFullPath(localRepoPath);
+
+            if (!Directory.Exists(localRepoPathFull))
+            {
+                throw new DirectoryNotFoundException($"The directory '{localRepoPathFull}' does not exist.");
+            }
+        }
+
+        return localRepoPathFull;
+    }
+
+    /// <summary>
+    /// Parse the '--exclude-overview-section' argument from the command line.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <returns>Whether to exclude the overview section.</returns>
+    private static bool ParseExcludeOverviewSectionArgument(ParseResult parseResult)
+    {
+        bool excludeOverviewSection = parseResult.GetValue<bool>("--exclude-overview-section");
+
+        return excludeOverviewSection;
+    }
+}


### PR DESCRIPTION
## Description

This PR makes a few changes to arguments for the `create-text` command:

* Passed arguments are parsed in their own class.
* `--base-tag` has been renamed to `--base-ref`.
* `--new-tag` has been renamed to `--target-ref`.
* `--repo` has been renamed to `--repo-name`.
* `--target-ref` now defaults to `HEAD`.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None