### PR TITLE
Fix GetCommitInfoAsync hanging

### DIFF
--- a/src/ConsoleApp/Models/Git/CommitInfo.cs
+++ b/src/ConsoleApp/Models/Git/CommitInfo.cs
@@ -66,8 +66,8 @@ public sealed partial class CommitInfo
         ProcessStartInfo processStartInfo = CreateGitProcessStartInfo(
             arguments: [
                 "log",
-                "--no-patch",
                 "--format='%h - %S - %s'",
+                "-1",
                 _inputRef
             ],
             workingDirectory: _repoPath ?? Environment.CurrentDirectory


### PR DESCRIPTION
## Description

This PR should fix the `GetCommitInfoAsync` method in the `CommitInfo` class from causing the tool to hang.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None