### PR TITLE
Add '--no-pager' to git log output

### DIFF
--- a/src/ConsoleApp/Models/Git/CommitInfo.cs
+++ b/src/ConsoleApp/Models/Git/CommitInfo.cs
@@ -65,6 +65,7 @@ public sealed partial class CommitInfo
     {
         ProcessStartInfo processStartInfo = CreateGitProcessStartInfo(
             arguments: [
+                "--no-pager",
                 "log",
                 "--format='%h - %S - %s'",
                 "-1",

--- a/src/ConsoleApp/Models/Git/CommitsCollection.cs
+++ b/src/ConsoleApp/Models/Git/CommitsCollection.cs
@@ -70,6 +70,7 @@ public sealed partial class CommitsCollection
 
         ProcessStartInfo processStartInfo = CreateGitProcessStartInfo(
             arguments: [
+                "--no-pager",
                 "log",
                 $"{_baseCommitRef.RefName}..{_newCommitRef.RefName}",
                 "--reverse",


### PR DESCRIPTION
## Description

In addition to #8, this PR will prevent the `git` process from hanging due to it "paging" the output.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None