### PR TITLE
Add an extra dot in the "Full changelog" link

### DIFF
--- a/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
+++ b/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
@@ -180,7 +180,7 @@ public partial class CreateTextCommandAction : AsynchronousCliAction
         }
 
         // Add the full changelog section to the release text.
-        releaseText.AppendLine($"\n**Full Changelog**: [`{baseCommitRef.RefName}..{newCommitRef.RefName}`]({repoUrl}/compare/{baseCommitRef.RefName}..{newCommitRef.RefName})");
+        releaseText.AppendLine($"\n**Full Changelog**: [`{baseCommitRef.RefName}...{newCommitRef.RefName}`]({repoUrl}/compare/{baseCommitRef.RefName}...{newCommitRef.RefName})");
 
         // Write the release text to the console.
         ConsoleUtils.WriteOutput(releaseText.ToString());


### PR DESCRIPTION
## Description

This PR adds an extra dot (`.`) in the **Full changelog** link. Two dots (`..`) only shows the modified files, but three dots (`...`) shows the modified files and the commits.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None