### PR TITLE
Add separate project label config options

### DIFF
--- a/src/ConsoleApp/Extensions/ReleaseText/StringBuilderExtensions.cs
+++ b/src/ConsoleApp/Extensions/ReleaseText/StringBuilderExtensions.cs
@@ -1,0 +1,155 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+using GitHubReleaseGen.ConsoleApp.Models.GitHub;
+
+namespace GitHubReleaseGen.ConsoleApp.Extensions.ReleaseText;
+
+/// <summary>
+/// Extension methods to create release text using <see cref="StringBuilder"/>.
+/// </summary>
+internal static partial class StringBuilderExtensions
+{
+    /// <summary>
+    /// Adds the what's changed section to the release text.
+    /// </summary>
+    /// <param name="stringBuilder">The string builder.</param>
+    /// <param name="pullRequests">The pull requests to add.</param>
+    /// <param name="isSeparateProject">Whether the project is a separate project.</param>
+    /// <returns>The string builder with the what's changed section added.</returns>
+    public static StringBuilder AddWhatsChangedSection(this StringBuilder stringBuilder, GitHubPullRequest[] pullRequests, bool isSeparateProject)
+    {
+        if (pullRequests.Length != 0)
+        {
+            stringBuilder.AppendLine(!isSeparateProject ? "### ✍️ What's Changed\n" : "\n#### ✍️ What's Changed\n");
+
+            foreach (var prItem in pullRequests)
+            {
+                stringBuilder.AppendLine($"* {prItem.Title} by @{prItem.Author.Login} in #{prItem.Number}");
+            }
+        }
+
+        return stringBuilder;
+    }
+
+    /// <summary>
+    /// Adds the bug fixes section to the release text.
+    /// </summary>
+    /// <param name="stringBuilder">The string builder.</param>
+    /// <param name="pullRequests">The pull requests to add.</param>
+    /// <param name="isSeparateProject">Whether the project is a separate project.</param>
+    /// <returns>The string builder with the bug fixes section added.</returns>
+    public static StringBuilder AddBugFixesSection(this StringBuilder stringBuilder, GitHubPullRequest[] pullRequests, bool isSeparateProject)
+    {
+        if (pullRequests.Length != 0)
+        {
+            stringBuilder.AppendLine(!isSeparateProject ? "### 🪳 Bug Fixes\n" : "\n#### 🪳 Bug Fixes\n");
+
+            foreach (var prItem in pullRequests)
+            {
+                stringBuilder.AppendLine($"* {prItem.Title} by @{prItem.Author.Login} in #{prItem.Number}");
+            }
+        }
+
+        return stringBuilder;
+    }
+
+    /// <summary>
+    /// Adds the maintenance section to the release text. 
+    /// </summary>
+    /// <param name="stringBuilder">The string builder.</param>
+    /// <param name="pullRequests">The pull requests to add.</param>
+    /// <returns>The string builder with the maintenance section added.</returns>
+    public static StringBuilder AddMaintenanceSection(this StringBuilder stringBuilder, GitHubPullRequest[] pullRequests)
+    {
+        if (pullRequests.Length != 0)
+        {
+            stringBuilder.AppendLine("\n### 🧹 Maintenance\n");
+
+            foreach (var prItem in pullRequests)
+            {
+                stringBuilder.AppendLine($"* {prItem.Title} by @{prItem.Author.Login} in #{prItem.Number}");
+            }
+        }
+
+        return stringBuilder;
+    }
+
+    /// <summary>
+    /// Adds the dependency updates section to the release text.
+    /// </summary>
+    /// <param name="stringBuilder">The string builder.</param>
+    /// <param name="pullRequests">The pull requests to add.</param>
+    /// <returns>The string builder with the dependency updates section added.</returns>
+    public static StringBuilder AddDependencyUpdatesSection(this StringBuilder stringBuilder, GitHubPullRequest[] pullRequests)
+    {
+        if (pullRequests.Length != 0)
+        {
+            stringBuilder.AppendLine("\n### ⛓️ Dependency updates\n");
+
+            foreach (var prItem in pullRequests)
+            {
+                string dependencyUpdateTitle = PrettifyDependencyUpdateText(prItem.Title);
+                stringBuilder.AppendLine($"* {dependencyUpdateTitle} by @{prItem.Author.Login.Replace("app/", "")} in #{prItem.Number}");
+            }
+        }
+
+        return stringBuilder;
+    }
+
+    /// <summary>
+    /// Prettifies the dependency update text.
+    /// </summary>
+    /// <param name="text">The text to prettify.</param>
+    /// <returns>The prettified text.</returns>
+    private static string PrettifyDependencyUpdateText(string text)
+    {
+        if (!DependencyUpdateRegex().IsMatch(text))
+        {
+            return text;
+        }
+
+        Match dependencyUpdateMatch = DependencyUpdateRegex().Match(text);
+
+        string modifiedText = text;
+
+        if (dependencyUpdateMatch.Groups["dependencyName"].Success)
+        {
+            modifiedText = modifiedText.Replace(
+                oldValue: dependencyUpdateMatch.Groups["dependencyName"].Value,
+                newValue: $"**{dependencyUpdateMatch.Groups["dependencyName"].Value}**"
+            );
+        }
+
+        if (dependencyUpdateMatch.Groups["previousVersion"].Success)
+        {
+            modifiedText = modifiedText.Replace(
+                oldValue: dependencyUpdateMatch.Groups["previousVersion"].Value,
+                newValue: $"`{dependencyUpdateMatch.Groups["previousVersion"].Value}`"
+            );
+        }
+
+        if (dependencyUpdateMatch.Groups["newVersion"].Success)
+        {
+            modifiedText = modifiedText.Replace(
+                oldValue: dependencyUpdateMatch.Groups["newVersion"].Value,
+                newValue: $"`{dependencyUpdateMatch.Groups["newVersion"].Value}`"
+            );
+        }
+
+        if (dependencyUpdateMatch.Groups["projectPath"].Success)
+        {
+            modifiedText = modifiedText.Replace(
+                oldValue: dependencyUpdateMatch.Groups["projectPath"].Value,
+                newValue: $"`{dependencyUpdateMatch.Groups["projectPath"].Value}`"
+            );
+        }
+
+        return modifiedText;
+    }
+
+    [GeneratedRegex(
+        pattern: "Bump (?'dependencyName'.+?) from (?'previousVersion'.+?) to (?'newVersion'.+?)(?>$| in (?'projectPath'.+))"
+    )]
+    internal static partial Regex DependencyUpdateRegex();
+}

--- a/src/ConsoleApp/JsonSourceGen/ConfigJsonContext.cs
+++ b/src/ConsoleApp/JsonSourceGen/ConfigJsonContext.cs
@@ -10,5 +10,7 @@ namespace GitHubReleaseGen.ConsoleApp;
 )]
 [JsonSerializable(typeof(RootConfig))]
 [JsonSerializable(typeof(LabelsConfig))]
+[JsonSerializable(typeof(SeparateProjectLabelConfig))]
+[JsonSerializable(typeof(ProjectLabelItem))]
 internal partial class ConfigJsonContext : JsonSerializerContext
 {}

--- a/src/ConsoleApp/Models/Configs/ProjectLabelItem.cs
+++ b/src/ConsoleApp/Models/Configs/ProjectLabelItem.cs
@@ -1,0 +1,19 @@
+namespace GitHubReleaseGen.ConsoleApp.Models.Configs;
+
+/// <summary>
+/// Defines a project label item.
+/// </summary>
+public sealed class ProjectLabelItem
+{
+    /// <summary>
+    /// The display name of the label.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// The label value.
+    /// </summary>
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = null!;
+}

--- a/src/ConsoleApp/Models/Configs/RootConfig.cs
+++ b/src/ConsoleApp/Models/Configs/RootConfig.cs
@@ -10,7 +10,14 @@ public sealed class RootConfig
     /// <summary>
     /// Configuration options for the labels.
     /// </summary>
+    [JsonPropertyName("labels")]
     public LabelsConfig Labels { get; set; } = new();
+
+    /// <summary>
+    /// Configuration options for the separate project label.
+    /// </summary>
+    [JsonPropertyName("separateProjectLabel")]
+    public SeparateProjectLabelConfig SeparateProjectLabel { get; set; } = new();
 
     /// <summary>
     /// Gets the configuration file.

--- a/src/ConsoleApp/Models/Configs/SeparateProjectLabelConfig.cs
+++ b/src/ConsoleApp/Models/Configs/SeparateProjectLabelConfig.cs
@@ -1,0 +1,19 @@
+namespace GitHubReleaseGen.ConsoleApp.Models.Configs;
+
+/// <summary>
+/// Configuration options for the separate project label.
+/// </summary>
+public sealed class SeparateProjectLabelConfig
+{
+    /// <summary>
+    /// Whether the separate project label is enabled.
+    /// </summary>
+    [JsonPropertyName("enable")]
+    public bool Enable { get; set; } = false;
+
+    /// <summary>
+    /// The project labels.
+    /// </summary>
+    [JsonPropertyName("projectLabels")]
+    public ProjectLabelItem[] ProjectLabels { get; set; } = [];
+}


### PR DESCRIPTION
## Description

* Adds the ability to separate out multiple projects in a repo into their own sections.

### Type of change

- [x] 🌟 New feature
- [ ] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None