### PR TITLE
Separate projects with zero PRs still appear

### DIFF
--- a/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
+++ b/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
@@ -143,9 +143,8 @@ public partial class CreateTextCommandAction : AsynchronousCliAction
             {
                 GitHubPullRequest[] featureAndEnhancementPrs = GetFeatureAndEnhancementPullRequests(pullRequestsSinceTag, config, projectLabel.Label);
                 GitHubPullRequest[] bugFixPrsForProject = GetBugFixPullRequests(pullRequestsSinceTag, config, projectLabel.Label);
-                GitHubPullRequest[] maintenancePrsForProject = GetMaintenancePullRequests(pullRequestsSinceTag, config);
 
-                if (featureAndEnhancementPrs.Length == 0 && bugFixPrsForProject.Length == 0 && maintenancePrsForProject.Length == 0)
+                if (featureAndEnhancementPrs.Length == 0 && bugFixPrsForProject.Length == 0)
                 {
                     continue;
                 }

--- a/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
+++ b/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
@@ -144,16 +144,14 @@ public partial class CreateTextCommandAction : AsynchronousCliAction
                 GitHubPullRequest[] featureAndEnhancementPrs = GetFeatureAndEnhancementPullRequests(pullRequestsSinceTag, config, projectLabel.Label);
                 GitHubPullRequest[] bugFixPrsForProject = GetBugFixPullRequests(pullRequestsSinceTag, config, projectLabel.Label);
 
-                if (featureAndEnhancementPrs.Length == 0 && bugFixPrsForProject.Length == 0)
+                if (featureAndEnhancementPrs.Length != 0 && bugFixPrsForProject.Length != 0)
                 {
-                    continue;
+                    releaseText
+                        .AppendLine($"### {projectLabel.Name}")
+                        .AppendLine()
+                        .AddWhatsChangedSection(featureAndEnhancementPrs, true)
+                        .AddBugFixesSection(bugFixPrsForProject, true);
                 }
-
-                releaseText
-                    .AppendLine($"### {projectLabel.Name}")
-                    .AppendLine()
-                    .AddWhatsChangedSection(featureAndEnhancementPrs, true)
-                    .AddBugFixesSection(bugFixPrsForProject, true);
             }
 
             GitHubPullRequest[] otherFeatureAndEnhancementPrs = GetOtherFeatureAndEnhancementPullRequests(pullRequestsSinceTag, config);


### PR DESCRIPTION
## Description

* Fixes headings for defined separate projects still showing up when they have zero PRs.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None