### PR TITLE
Fix blank output when separate projects is enabled

### DIFF
--- a/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
+++ b/src/ConsoleApp/Commands/CreateTextCommand/CreateTextCommandAction.cs
@@ -143,7 +143,7 @@ public partial class CreateTextCommandAction : AsynchronousCliAction
                 GitHubPullRequest[] featureAndEnhancementPrs = GetFeatureAndEnhancementPullRequests(pullRequestsSinceTag, config, projectLabel.Label);
                 GitHubPullRequest[] bugFixPrsForProject = GetBugFixPullRequests(pullRequestsSinceTag, config, projectLabel.Label);
 
-                if (featureAndEnhancementPrs.Length != 0 && bugFixPrsForProject.Length != 0)
+                if (featureAndEnhancementPrs.Length != 0 || bugFixPrsForProject.Length != 0)
                 {
                     releaseText
                         .AppendLine($"### {projectLabel.Name}")


### PR DESCRIPTION
## Description

* Fixes a bug where the generated text is blank when the **separate projects** option is enabled.
* Modifies the logic when evaluating whether or not a project should be added.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None